### PR TITLE
Use uname -m over uname --processor

### DIFF
--- a/info_rewrite.sh
+++ b/info_rewrite.sh
@@ -3,7 +3,7 @@
 # Jus de Patate <yaume@ntymail.com>
 # First release   :       2018.11.10-01
 # Rewrite release :       2019.01.01-16
-                 VERSION="2020.02.24-01"; indev=true
+                 VERSION="2020.02.22-02"; indev=true
 #                         yyyy.mm.dd
 #
 # info.sh is a little script that works like `neofetch` or `screenfetch`
@@ -232,10 +232,10 @@ getos() {
     verbose "[getos()] Getting arch from uname"
     verbose
 
-    if [ "$(uname -m)" ]; then
-        ARCH="$(uname -m)"
-    else
+    if [ "$(uname --processor)" ]; then
         ARCH="$(uname --processor)"
+    else
+        ARCH="$(uname -m)"
     fi
 
     print "Arch: ${BOLD}$ARCH${NORMAL}"

--- a/info_rewrite.sh
+++ b/info_rewrite.sh
@@ -3,7 +3,7 @@
 # Jus de Patate <yaume@ntymail.com>
 # First release   :       2018.11.10-01
 # Rewrite release :       2019.01.01-16
-                 VERSION="2020.02.22-02"; indev=true
+                 VERSION="2020.02.24-01"; indev=true
 #                         yyyy.mm.dd
 #
 # info.sh is a little script that works like `neofetch` or `screenfetch`
@@ -232,10 +232,10 @@ getos() {
     verbose "[getos()] Getting arch from uname"
     verbose
 
-    if [ "$(uname --processor)" ]; then
-        ARCH="$(uname --processor)"
-    else
+    if [ "$(uname -m)" ]; then
         ARCH="$(uname -m)"
+    else
+        ARCH="$(uname --processor)"
     fi
 
     print "Arch: ${BOLD}$ARCH${NORMAL}"

--- a/info_rewrite.sh
+++ b/info_rewrite.sh
@@ -234,6 +234,9 @@ getos() {
 
     if [ "$(uname --processor)" ]; then
         ARCH="$(uname --processor)"
+        if [ $ARCH == "unknown" ]; then
+        	ARCH="$(uname -m)"
+        fi
     else
         ARCH="$(uname -m)"
     fi


### PR DESCRIPTION
uname -m seems to be more accurate. On some platforms, uname --processor returns "unknown".

![image](https://user-images.githubusercontent.com/22567851/75189900-8003ff80-574f-11ea-9dc3-e14ab7451fc4.png)

![image](https://user-images.githubusercontent.com/22567851/75189934-927e3900-574f-11ea-8cdc-8a2f34f00edd.png)
